### PR TITLE
Added setting AWS env variables from serverless config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kalarrs/serverless-local-dev-server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "engines": {
     "node": ">=6.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,8 @@ class ServerlessLocalDevServerPlugin {
   start () {
     this.server = new Server()
     this.server.log = this.serverless.cli.log.bind(this.serverless.cli)
+    if (this.serverless.service.provider.profile) this.server.customEnvironment.AWS_PROFILE = this.serverless.service.provider.profile
+    if (this.serverless.service.provider.region) this.server.customEnvironment.AWS_REGION = this.serverless.service.provider.region
     Object.assign(this.server.customEnvironment, this.options.environment)
     this.server.setConfiguration(this.serverless.service, this.serverless.config.servicePath)
     let customPort = this.serverless.service && this.serverless.service.custom && this.serverless.service.custom.localDevPort

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,8 @@ describe('index.js', () => {
   })
 
   it('should set environment variables correctly', () => {
+    serverless.service.provider.profile = 'default';
+    serverless.service.provider.region = 'us-west-2';
     serverless.service.provider.environment = {
       foo: 'bar',
       bla: 'blub',
@@ -171,7 +173,8 @@ describe('index.js', () => {
       expect(json.IS_LOCAL).equal(true)
       expect(json.foo).equal('baz')
       expect(json.bla).equal('blub')
-      expect(json.la).equal('lala')
+      expect(json.AWS_PROFILE).equal('default')
+      expect(json.AWS_REGION).equal('us-west-2')
     })
   })
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "DieProduktMacher/serverless-local-dev-server" submits your change to ALL USERS OF THIS PLUGIN, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->